### PR TITLE
DSND-1129 Simplify mixed alphanumeric regex pattern

### DIFF
--- a/src/main/java/uk/gov/companieshouse/charges/delta/mapper/TextFormatter.java
+++ b/src/main/java/uk/gov/companieshouse/charges/delta/mapper/TextFormatter.java
@@ -20,7 +20,7 @@ public class TextFormatter {
     private static final Pattern COLON_PATTERN =
             Pattern.compile("[;:]$");
     private static final Pattern MIXED_ALNUM_PATTERN =
-            Pattern.compile("\\p{L}+\\p{N}+|\\p{N}+\\p{L}+");
+            Pattern.compile("\\p{L}\\p{N}|\\p{N}\\p{L}");
     private static final Pattern ABBREVIATION_PATTERN =
             Pattern.compile("(\\P{L})*(\\p{L}[.])+");
     private static final Pattern I_PATTERN =


### PR DESCRIPTION
* Use of java.util.regex.Matcher.find() means that identifying boundary between letter and number is sufficient.