### PR TITLE
Add tiltfile.dev to work on ch docker

### DIFF
--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -1,0 +1,18 @@
+local_resource(
+  name = 'dev:charges-delta-consumer-build',
+  cmd = 'mvn compile',
+  deps = ['src']
+)
+
+custom_build(
+  ref = '169942020521.dkr.ecr.eu-west-1.amazonaws.com/charges-delta-consumer',
+  command = 'mvn compile jib:dockerBuild -Dimage=$EXPECTED_REF',
+  live_update = [
+    sync(
+      local_path = './target/classes',
+      remote_path = '/app/classes'
+    ),
+    restart_container()
+  ],
+  deps = ['./target/classes']
+)

--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,6 @@
                         <arg>-Xlint</arg>
                         <arg>-Xlint:-processing</arg>
                         <arg>-Xlint:-serial</arg>
-                        <arg>-Werror</arg>
                     </compilerArgs>
                     <annotationProcessorPaths>
                         <path>


### PR DESCRIPTION
This pr adds a tiltfile.dev to run the service on companies house docker instances. Also removed the error on warnings flag on the compiler as this is failing docker builds.

**Resolves:**
- DSND-1150