### PR TITLE
DSND-1158 Fix bug so word is sentence cased if it matches new regex pattern

### DIFF
--- a/src/test/java/uk/gov/companieshouse/charges/delta/mapper/TextFormatterTest.java
+++ b/src/test/java/uk/gov/companieshouse/charges/delta/mapper/TextFormatterTest.java
@@ -171,6 +171,8 @@ class TextFormatterTest {
                 Arguments.of("\\n\\n", "."),
                 Arguments.of("\\nHello", "Hello."),
                 Arguments.of("this is a word with two full stops.. so is this..\\n", "This is a word with two full stops.. So is this.."),
+                Arguments.of("this is a sentence that contains sequence AB.1234. sentence casing should apply after the full stop",
+                        "This is a sentence that contains sequence ab.1234. Sentence casing should apply after the full stop."),
                 Arguments.of("Hello\\n\\nWorld", "Hello. World."),
                 Arguments.of("Hello\\n \\n \\nWorld", "Hello. World."),
                 Arguments.of("\\np/office the d.r. of an lLp saYs a cAT is ) for ChrIstmAS etc.  \\n\\n\t but i\tthink (a cat) is 4life! æthelred is ready", "P/Office the D.R. of an LLP says a cat is ) for christmas etc.. but I think (a cat) is 4LIFE! æThelred is ready.")


### PR DESCRIPTION
* Add new regex pattern to identify sequence of full stops and numeric characters
* Add new boolean field inside the inner class SentenceState
* Add logic to change above boolean based on whether regex is matched
* All unit tests passes and new test case added and runs succesfully

Resolves [DSND-1158](https://companieshouse.atlassian.net/browse/DSND-1158)