### PR TITLE
Fix transactions top level status

### DIFF
--- a/src/main/java/uk/gov/companieshouse/charges/delta/transformer/ChargesApiTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/charges/delta/transformer/ChargesApiTransformer.java
@@ -9,9 +9,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.support.KafkaHeaders;
@@ -135,13 +133,13 @@ public class ChargesApiTransformer {
             transactionsApi.setDeliveredOn(LocalDate.parse(charge.getDeliveredOn(),
                     DateTimeFormatter.ofPattern("yyyyMMdd")));
         }
-        Optional<List<TransactionsApi>> transactionsApiListOptional =
-                Optional.ofNullable(chargeApi.getTransactions());
-        transactionsApiListOptional.ifPresentOrElse(
-                (transactionsApiList) -> transactionsApiList.add(0, transactionsApi),
-                () -> chargeApi.addTransactionsItem(transactionsApi)
-        );
-        sortListBasedOnDeliveredOnDate(chargeApi);
+
+        if (chargeApi.getTransactions() != null) {
+            sortListBasedOnDeliveredOnDate(chargeApi);
+            chargeApi.getTransactions().add(0, transactionsApi);
+        } else {
+            chargeApi.addTransactionsItem(transactionsApi);
+        }
     }
 
     private void sortListBasedOnDeliveredOnDate(ChargeApi chargeApi) {


### PR DESCRIPTION
This PR is to fix the transaction list from a charges delta so that the main transaction is always at the top of the transaction list once saved in mongo. In return, CHS will display the correct 'Transaction filed'.

**Resolves**
- DSND-1127