### PR TITLE
Add broken filing-history link check

### DIFF
--- a/src/itest/resources/features/charges-consumer-happy-path.feature
+++ b/src/itest/resources/features/charges-consumer-happy-path.feature
@@ -24,7 +24,7 @@ Feature: Process Charges Delta information
     | charges-delta-source-3.json                          | internal-charges-api-expected-3.json                        |
     | charges-delta-source-19.json                         | internal-charges-api-expected-19.json                       |
     | charges-delta-source-20.json                         | internal-charges-api-expected-20.json                       |
-
+    | Additional_notices_No_Trans_Id.json                  | Additional_notices_No_Trans_Id_output.json                  |
 
 
 

--- a/src/itest/resources/payloads/input/Additional_notices_No_Trans_Id.json
+++ b/src/itest/resources/payloads/input/Additional_notices_No_Trans_Id.json
@@ -1,0 +1,62 @@
+{
+  "charges": [
+    {
+      "company_number": "08124207",
+      "delta_at": "20211029142043360560",
+      "id": "3001283055",
+      "persons_entitled": [
+        {
+          "person": "LYELL TRADING LIMITED"
+        }
+      ],
+      "notice_type": "MR01",
+      "trans_id": "",
+      "trans_desc": "REGISTRATION OF A CHARGE / CHARGE CODE  081242070049",
+      "submission_type": "2",
+      "delivered_on": "20191017",
+      "more_than_4_persons": "N",
+      "additional_notices": [
+        {
+          "notice_type": "MR05",
+          "trans_id": "3247323133",
+          "trans_desc": "STATEMENT OF RELEASE / CEASE FROM CHARGE / PART BOTH / CHARGE CODE 081242070049",
+          "submission_type": "2",
+          "delivered_on": "20191022"
+        },
+        {
+          "notice_type": "MR04",
+          "trans_id": "3247979346",
+          "trans_desc": "STATEMENT OF SATISFACTION OF A CHARGE / PART / CHARGE CODE 081242070049",
+          "submission_type": "2",
+          "delivered_on": "20191029"
+        },
+        {
+          "notice_type": "MR05",
+          "trans_id": "3248292521",
+          "trans_desc": "STATEMENT OF RELEASE / CEASE FROM CHARGE / PART RELEASE / CHARGE CODE 081242070049",
+          "submission_type": "2",
+          "delivered_on": "20191101"
+        }
+      ],
+      "code": "081242070049",
+      "charge_number": "49",
+      "migrated_from": "CHIPS",
+      "type": "A REGISTERED CHARGE",
+      "brief_description": "THE FREEHOLD LAND KNOWN AS MILLENNIUM HOUSE, 60 VICTORIA STREET, LIVERPOOL AND REGISTERED WITH HM LAND REGISTRY UNDER TITLE NUMBER MS303172\\n",
+      "short_particular_flags": [
+        {
+          "fixed_charge": "yes",
+          "contains_floating_charge": "yes",
+          "floating_charge_all": "yes",
+          "negative_pledge": "yes",
+          "bare_trustee": "no"
+        }
+      ],
+      "status": "2",
+      "assets_ceased_released": "9",
+      "delivered_on": "20191017",
+      "floating_charge": "Y",
+      "created_on": "20191011"
+    }
+  ]
+}

--- a/src/itest/resources/payloads/output/Additional_notices_No_Trans_Id_output.json
+++ b/src/itest/resources/payloads/output/Additional_notices_No_Trans_Id_output.json
@@ -1,0 +1,84 @@
+{
+  "external_data": {
+    "persons_entitled": [
+      {
+        "name": "Lyell Trading Limited"
+      }
+    ],
+    "charge_number": 49,
+    "particulars": {
+      "floating_charge_covers_all": true,
+      "type": "brief-description",
+      "contains_floating_charge": true,
+      "description": "The freehold land known as millennium house, 60 victoria street, liverpool and registered with hm land registry under title number MS303172.",
+      "contains_fixed_charge": true,
+      "contains_negative_pledge": true,
+      "chargor_acting_as_bare_trustee": null
+    },
+    "scottish_alterations": {
+      "type": null,
+      "description": null,
+      "has_alterations_to_order": null,
+      "has_alterations_to_prohibitions": null
+    },
+    "charge_code": "081242070049",
+    "links": {
+      "self": "/company/08124207/charges/vxRpuvN7Cgiokh1jt3Io0u3maWY"
+    },
+    "created_on": [2019,10,11],
+    "transactions": [
+      {
+        "filing_type": "create-charge-with-deed",
+        "transaction_id": null,
+        "delivered_on": [2019,10,17],
+        "insolvency_case_number": null,
+        "links": {
+          "insolvency_case": null
+        }
+      },
+      {
+        "filing_type": "charge-part-both",
+        "transaction_id": null,
+        "delivered_on": [2019,10,22],
+        "insolvency_case_number": null,
+        "links": {
+          "insolvency_case": null
+        }
+      },
+      {
+        "filing_type": "charge-part-satisfaction",
+        "transaction_id": null,
+        "delivered_on": [2019,10,29],
+        "insolvency_case_number": null,
+        "links": {
+          "insolvency_case": null
+        }
+      },
+      {
+        "filing_type": "charge-part-release",
+        "transaction_id": null,
+        "delivered_on": [2019,11,1],
+        "insolvency_case_number": null,
+        "links": {
+          "insolvency_case": null
+        }
+      }
+    ],
+    "status": "part-satisfied",
+    "classification": {
+      "description": "A registered charge",
+      "type": "charge-description"
+    },
+    "delivered_on": [2019,10,17],
+    "assets_ceased_released": "multiple-filings",
+    "acquired_on": null,
+    "resolved_on": null,
+    "covering_instrument_date": null,
+    "more_than_four_persons_entitled": null,
+    "satisfied_on": null
+  },
+  "internal_data": {
+    "updated_by": "charges-delta-0-0",
+    "delta_at": "2015-06-25T22:00:00.000Z"
+  }
+}

--- a/src/test/java/uk/gov/companieshouse/charges/delta/processor/ChargesDeltaProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/charges/delta/processor/ChargesDeltaProcessorTest.java
@@ -234,6 +234,7 @@ public class ChargesDeltaProcessorTest {
     void When_ChsDelta_with_null_chargeId_Expect_ErrorResponse(String jsonFileName) throws IOException {
         Message<ChsDelta> mockChsChargesDeltaMessage = testSupport.createChsDeltaMessage(
                 jsonFileName, false);
+        when(transformer.transform(any(Charge.class), any(MessageHeaders.class))).thenReturn(testSupport.mockInternalChargeApi());
 
         assertThrows( NonRetryableErrorException.class,
                 () -> deltaProcessor.processDelta(mockChsChargesDeltaMessage));

--- a/src/test/java/uk/gov/companieshouse/charges/delta/util/TestSupport.java
+++ b/src/test/java/uk/gov/companieshouse/charges/delta/util/TestSupport.java
@@ -7,9 +7,11 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.FileCopyUtils;
+import uk.gov.companieshouse.api.charges.ChargeApi;
 import uk.gov.companieshouse.api.charges.ChargesApi;
 import uk.gov.companieshouse.api.charges.InternalChargeApi;
 import uk.gov.companieshouse.api.charges.InternalData;
+import uk.gov.companieshouse.api.charges.TransactionsApi;
 import uk.gov.companieshouse.api.delta.AdditionalNotice;
 import uk.gov.companieshouse.api.delta.Charge;
 import uk.gov.companieshouse.api.delta.ChargesDelta;
@@ -113,8 +115,12 @@ public class TestSupport {
     {
         InternalChargeApi internalChargeApi = new InternalChargeApi();
         InternalData internalData = new InternalData();
+        ChargeApi externalData = new ChargeApi();
+        List<TransactionsApi> transactions = new ArrayList<>();
+        externalData.setTransactions(transactions);
         internalData.setUpdatedBy("test-partition_1-offset_1");
         internalChargeApi.setInternalData(internalData);
+        internalChargeApi.setExternalData(externalData);
         return internalChargeApi;
 
     }


### PR DESCRIPTION
This PR adds a method to check if the filing history link for a transaction is missing the encoded Id and if so then removes the link completely. This happens when the transaction Id is blank.

**Resolves:**
- DSND-1004