### PR TITLE
DSND-1067 Rewrite regex testing for I

### DIFF
--- a/src/main/java/uk/gov/companieshouse/charges/delta/mapper/TextFormatter.java
+++ b/src/main/java/uk/gov/companieshouse/charges/delta/mapper/TextFormatter.java
@@ -51,6 +51,7 @@ public class TextFormatter {
                     "(^[^a-zA-Z]*([a-z][.])+))[^a-z]*\\s"),
             Pattern.CASE_INSENSITIVE);
     private static final Pattern SENTENCE_TERMINATOR = Pattern.compile("[.!?]");
+    private static final Pattern OPENING_BRACKET = Pattern.compile("[(\\[]");
     private static final Pattern CLOSING_BRACKET = Pattern.compile("[])]");
     private static final Pattern WHITESPACE = Pattern.compile("\\s");
 
@@ -300,14 +301,15 @@ public class TextFormatter {
         }
         token = token.toUpperCase(Locale.UK);
         for (int i = 0; i < token.length(); i++) {
-            if ((token.charAt(i) == '(' || token.charAt(i) == '[') && !result.possessive) {
+            String letter = Character.toString(token.charAt(i));
+            if (OPENING_BRACKET.matcher(letter).matches() && !result.possessive) {
                 result.openingBrackets = true;
-            } else if (Character.toUpperCase(token.charAt(i)) == 'I' && !result.possessive) {
+            } else if ("I".equals(letter.toUpperCase(Locale.UK)) && !result.possessive) {
                 result.possessive = true;
                 result.endOfSentence = false;
-            } else if (token.charAt(i) == '.' || token.charAt(i) == '!' || token.charAt(i) == '?') {
+            } else if (SENTENCE_TERMINATOR.matcher(letter).matches()) {
                 result.endOfSentence = true;
-            } else if(Character.isAlphabetic(token.charAt(i))) {
+            } else if(FIRST_LETTER.matcher(letter).matches()) {
                 return NON_POSSESSIVE;
             }
         }

--- a/src/main/java/uk/gov/companieshouse/charges/delta/mapper/TextFormatter.java
+++ b/src/main/java/uk/gov/companieshouse/charges/delta/mapper/TextFormatter.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.charges.delta.mapper;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.regex.Matcher;
@@ -39,12 +40,6 @@ public class TextFormatter {
     private static final Pattern ABBREVIATIONS = Pattern.compile("\\b(\\p{L})[.]");
     private static final Pattern MIXED_ALPHANUMERIC = Pattern.compile("(\\w+\\d+\\w*|\\d+\\w+)");
     private static final Pattern TOKENISATION_PATTERN = Pattern.compile("(\\S+(\\s+|$))");
-    private static final Pattern POSSESSIVE_PATTERN = Pattern.compile(
-            "^([^a-z]*)I[^a-z]",
-            Pattern.CASE_INSENSITIVE);
-    private static final Pattern POSSESSIVE_END_OF_SENTENCE_PATTERN = Pattern.compile(
-            "([.]|[!?]+)[^.!?a-z]*$"
-    );
     private static final Pattern FORWARDSLASH_ABBREVIATION = Pattern.compile("^(.?/)(.*)",
             Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
     private static final Pattern FIRST_LETTER = Pattern.compile("([a-z])",
@@ -199,12 +194,10 @@ public class TextFormatter {
     }
 
     private static String mapWord(String token, SentenceState sentenceState) {
-        Matcher possessivePatternMatcher = POSSESSIVE_PATTERN.matcher(token);
-        Matcher possessiveEndOfSentenceMatcher = POSSESSIVE_END_OF_SENTENCE_PATTERN.matcher(token);
-        if (possessivePatternMatcher.find()) {
-            sentenceState.setEndOfSentence(possessiveEndOfSentenceMatcher.find());
-            sentenceState.setMatchingBracket(
-                    possessivePatternMatcher.group(1).matches("^[\\[(].*$"));
+        Possessiveness possessive = isPossessive(token);
+        if (possessive.possessive) {
+            sentenceState.setEndOfSentence(possessive.endOfSentence);
+            sentenceState.setMatchingBracket(possessive.openingBrackets);
             return token.toUpperCase(Locale.UK);
         }
         token = token.toLowerCase(Locale.UK);
@@ -246,6 +239,79 @@ public class TextFormatter {
         }
         result.append(token.substring(prevEnd));
         return result.toString();
+    }
+
+    static class Possessiveness {
+        boolean possessive;
+        boolean openingBrackets;
+        boolean endOfSentence;
+
+        Possessiveness() {
+        }
+
+        Possessiveness(boolean possessive, boolean openingBrackets, boolean endOfSentence) {
+            this.possessive = possessive;
+            this.openingBrackets = openingBrackets;
+            this.endOfSentence = endOfSentence;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Possessiveness that = (Possessiveness) o;
+            return possessive == that.possessive && openingBrackets == that.openingBrackets && endOfSentence == that.endOfSentence;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(possessive, openingBrackets, endOfSentence);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder result = new StringBuilder();
+            if (possessive) {
+                result.append("possessive");
+            } else {
+                result.append("not possessive");
+                return result.toString();
+            }
+            if (openingBrackets) {
+                result.append(", opening brackets");
+            } else {
+                result.append(", no opening brackets");
+            }
+            if (endOfSentence) {
+                result.append(", end of sentence");
+            } else {
+                result.append(", not end of sentence");
+            }
+            return result.toString();
+        }
+    }
+
+    static final Possessiveness NON_POSSESSIVE = new Possessiveness();
+
+    static Possessiveness isPossessive(String token) {
+        Possessiveness result = new Possessiveness();
+        if (StringUtils.isEmpty(token)) {
+            return NON_POSSESSIVE;
+        }
+        token = token.toUpperCase(Locale.UK);
+        for (int i = 0; i < token.length(); i++) {
+            if ((token.charAt(i) == '(' || token.charAt(i) == '[') && !result.possessive) {
+                result.openingBrackets = true;
+            } else if (Character.toUpperCase(token.charAt(i)) == 'I' && !result.possessive) {
+                result.possessive = true;
+                result.endOfSentence = false;
+            } else if (token.charAt(i) == '.' || token.charAt(i) == '!' || token.charAt(i) == '?') {
+                result.endOfSentence = true;
+            } else if(Character.isAlphabetic(token.charAt(i))) {
+                return NON_POSSESSIVE;
+            }
+        }
+        return result;
     }
 
     enum SentenceTerminationState {

--- a/src/test/java/uk/gov/companieshouse/charges/delta/mapper/TextFormatterTest.java
+++ b/src/test/java/uk/gov/companieshouse/charges/delta/mapper/TextFormatterTest.java
@@ -185,7 +185,7 @@ class TextFormatterTest {
                 Arguments.of("This sentence contains brackets and sequence AB.1234. (sentence casing) applies inside the brackets and after the full stop.", "This sentence contains brackets and sequence ab.1234. (Sentence casing) applies inside the brackets and after the full stop."),
                 Arguments.of("(this sentence has closing brackets after a full stop.) this one does not.", "(This sentence has closing brackets after a full stop.) This one does not."),
                 Arguments.of("this sentence has an unmatched closing bracket after a full stop.) this one does not.", "This sentence has an unmatched closing bracket after a full stop.) this one does not."),
-                Arguments.of("THIS SENTENCE CONTAINS A WEIRD 2.2I AGREEMENT ACRONYM", "This sentence contains a weird 2.2I agreement acronym"),
+                Arguments.of("THIS SENTENCE CONTAINS AN ACRONYM 2.2I WITH AN I", "This sentence contains an acronym 2.2I with an I"),
                 Arguments.of("this sentence contains approximately (i)-(iii) roman numerals", "This sentence contains approximately (i)-(iii) roman numerals")
         );
     }

--- a/src/test/java/uk/gov/companieshouse/charges/delta/mapper/TextFormatterTest.java
+++ b/src/test/java/uk/gov/companieshouse/charges/delta/mapper/TextFormatterTest.java
@@ -63,6 +63,17 @@ class TextFormatterTest {
         assertEquals(expected, actual);
     }
 
+    @ParameterizedTest(name = "Possessiveness should be [{1}] for token [{0}]")
+    @MethodSource("possessiveState")
+    @DisplayName("Determine if provided token is possessive")
+    void testPossessiveness(String token, TextFormatter.Possessiveness expected) {
+        // when
+        TextFormatter.Possessiveness actual = TextFormatter.isPossessive(token);
+
+        // then
+        assertEquals(expected, actual);
+    }
+
     private static Stream<Arguments> entityNameFormatting() {
         return Stream.of(
                 Arguments.of(null, null),
@@ -173,7 +184,9 @@ class TextFormatterTest {
                 Arguments.of("This sentence contains sequence AB.1234. sentence casing should apply after the full stop", "This sentence contains sequence ab.1234. Sentence casing should apply after the full stop"),
                 Arguments.of("This sentence contains brackets and sequence AB.1234. (sentence casing) applies inside the brackets and after the full stop.", "This sentence contains brackets and sequence ab.1234. (Sentence casing) applies inside the brackets and after the full stop."),
                 Arguments.of("(this sentence has closing brackets after a full stop.) this one does not.", "(This sentence has closing brackets after a full stop.) This one does not."),
-                Arguments.of("this sentence has an unmatched closing bracket after a full stop.) this one does not.", "This sentence has an unmatched closing bracket after a full stop.) this one does not.")
+                Arguments.of("this sentence has an unmatched closing bracket after a full stop.) this one does not.", "This sentence has an unmatched closing bracket after a full stop.) this one does not."),
+                Arguments.of("THIS SENTENCE CONTAINS A WEIRD 2.2I AGREEMENT ACRONYM", "This sentence contains a weird 2.2I agreement acronym"),
+                Arguments.of("this sentence contains approximately (i)-(iii) roman numerals", "This sentence contains approximately (i)-(iii) roman numerals")
         );
     }
 
@@ -210,6 +223,29 @@ class TextFormatterTest {
                 Arguments.of("a.) ", TextFormatter.SentenceTerminationState.TERMINATED_WITH_BRACKET),
                 Arguments.of("a.) ", TextFormatter.SentenceTerminationState.TERMINATED_WITH_BRACKET),
                 Arguments.of("a). ", TextFormatter.SentenceTerminationState.TERMINATED)
+        );
+    }
+
+    private static Stream<Arguments> possessiveState() {
+        return Stream.of(
+                Arguments.of(null, TextFormatter.NON_POSSESSIVE),
+                Arguments.of("", TextFormatter.NON_POSSESSIVE),
+                Arguments.of("I", new TextFormatter.Possessiveness(true, false, false)),
+                Arguments.of("I.", new TextFormatter.Possessiveness(true, false, true)),
+                Arguments.of("I?", new TextFormatter.Possessiveness(true, false, true)),
+                Arguments.of("I!", new TextFormatter.Possessiveness(true, false, true)),
+                Arguments.of("-I", new TextFormatter.Possessiveness(true, false, false)),
+                Arguments.of("you", TextFormatter.NON_POSSESSIVE),
+                Arguments.of("(I", new TextFormatter.Possessiveness(true, true, false)),
+                Arguments.of("[I", new TextFormatter.Possessiveness(true, true, false)),
+                Arguments.of("[I.", new TextFormatter.Possessiveness(true, true, true)),
+                Arguments.of("I.(", new TextFormatter.Possessiveness(true, false, true)),
+                Arguments.of("I(.", new TextFormatter.Possessiveness(true, false, true)),
+                Arguments.of("I(.", new TextFormatter.Possessiveness(true, false, true)),
+                Arguments.of(".I", new TextFormatter.Possessiveness(true, false, false)),
+                Arguments.of("sublime", TextFormatter.NON_POSSESSIVE),
+                Arguments.of("I..", new TextFormatter.Possessiveness(true, false, true)),
+                Arguments.of("II", TextFormatter.NON_POSSESSIVE)
         );
     }
 }


### PR DESCRIPTION
* Rewrite regex testing for letter I in a token to fix potential issue with
acronyms.

Related:
[DSND-1067](https://companieshouse.atlassian.net/browse/DSND-1067)