### PR TITLE
DSND-2995: Changed the exception handlers to be more lenient

### DIFF
--- a/src/test/java/uk/gov/companieshouse/charges/delta/processor/ChargesDeltaProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/charges/delta/processor/ChargesDeltaProcessorTest.java
@@ -115,7 +115,7 @@ public class ChargesDeltaProcessorTest {
 
     @Test
     @DisplayName("When can't transform into charges delta API, throws retryable error")
-    void When_CantTransformIntoChargesDeltaApi_RetryableError() throws IOException {
+    void When_CantTransformIntoChargesDeltaApi_RetryableError() {
         Message<ChsDelta> invalidChsDeltaMessage = testSupport.createInvalidChsDeltaMessage(false);
         assertThrows(NonRetryableErrorException.class, () -> deltaProcessor.processDelta(invalidChsDeltaMessage));
     }
@@ -138,7 +138,7 @@ public class ChargesDeltaProcessorTest {
 
     @Test
     @DisplayName("When mapping an invalid ChsDelta message into Charges Delete Delta then throws a non-retryable exception")
-    void When_Invalid_ChargesDeleteDelta_nonRetryableError() throws IOException {
+    void When_Invalid_ChargesDeleteDelta_nonRetryableError() {
         Message<ChsDelta> invalidChsChargesDeltaDeltaMessage = testSupport.createInvalidChsDeltaMessage(true);
         Assertions.assertThrows(NonRetryableErrorException.class, () -> deltaProcessor.processDelete(invalidChsChargesDeltaDeltaMessage));
     }
@@ -176,6 +176,7 @@ public class ChargesDeltaProcessorTest {
     private static Stream<Arguments> provideExceptionParameters() {
         return Stream.of(
                 Arguments.of(HttpStatus.BAD_REQUEST, NonRetryableErrorException.class),
+                Arguments.of(HttpStatus.CONFLICT, NonRetryableErrorException.class),
                 Arguments.of(HttpStatus.NOT_FOUND, RetryableErrorException.class),
                 Arguments.of(HttpStatus.UNAUTHORIZED, RetryableErrorException.class),
                 Arguments.of(HttpStatus.INTERNAL_SERVER_ERROR, RetryableErrorException.class)


### PR DESCRIPTION
* Only API statuses of CONFLICT and BAD_REQUEST are non-retryable
* Updated the logging content

The outstanding tech debt in this service will be addressed in another Jira

[DSND-2995](https://companieshouse.atlassian.net/browse/DSND-2995)

[DSND-2995]: https://companieshouse.atlassian.net/browse/DSND-2995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ