### PR TITLE
DSND-3116: Pass in deltaAt to API call

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <ch-kafka.version>1.4.8</ch-kafka.version>
         <structured-logging.version>1.9.38</structured-logging.version>
         <kafka-models.version>1.0.40</kafka-models.version>
-        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.469</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.12</api-sdk-manager-java-library.version>
         <jib-maven-plugin.version>3.4.3</jib-maven-plugin.version>
         <wiremock.standalone.version>3.9.1</wiremock.standalone.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <ch-kafka.version>1.4.8</ch-kafka.version>
         <structured-logging.version>1.9.38</structured-logging.version>
         <kafka-models.version>1.0.40</kafka-models.version>
-        <private-api-sdk-java.version>2.0.444</private-api-sdk-java.version>
+        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.12</api-sdk-manager-java-library.version>
         <jib-maven-plugin.version>3.4.3</jib-maven-plugin.version>
         <wiremock.standalone.version>3.9.1</wiremock.standalone.version>
@@ -39,7 +39,7 @@
         <skip.integration.tests>false</skip.integration.tests>
         <skip.unit.tests>false</skip.unit.tests>
         <assertj-core.version>3.26.3</assertj-core.version>
-        <test-containers.version>1.20.1</test-containers.version>
+        <test-containers.version>1.20.3</test-containers.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
 
         <!--sonar configuration-->

--- a/src/itest/java/uk/gov/companieshouse/charges/delta/steps/ChargesConsumerDeleteSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/charges/delta/steps/ChargesConsumerDeleteSteps.java
@@ -46,7 +46,7 @@ public class ChargesConsumerDeleteSteps {
     public static final String TAGS = "tags";
     public static final String STUBBED_FOR_DELETE_TEST = "stubbed_for_delete_test";
     public static final String RETRY_TOPIC_ATTEMPTS = "retry_topic-attempts";
-    public static final String DELETE_URL = "/company/%s/charges/%s";
+    public static final String DELETE_URL = "/company/%s/charge/%s/internal";
 
     @Autowired
     public KafkaTemplate<String, Object> kafkaTemplate;

--- a/src/itest/resources/features/charges-delta-consumer-delete-flows.feature
+++ b/src/itest/resources/features/charges-delta-consumer-delete-flows.feature
@@ -10,7 +10,7 @@ Feature: Process Charges Delete Delta information with happy and error condition
 
     Examples:
       | response |  deltaMessage                       | companyNumber | chargeId                    | responseCode |
-      | 200      |  charges-delete-delta-source-1.json | 0             | NLVXY861zxOTr3NExemI3q4Nq4Y | 200          |
+      | 200      |  charges-delete-delta-source-1.json | 12345678      | NLVXY861zxOTr3NExemI3q4Nq4Y | 200          |
 
 
   Scenario Outline: Consume a valid Charges Delete message in avro format message with an invalid json payload,

--- a/src/itest/resources/features/charges-delta-consumer-delete-flows.feature
+++ b/src/itest/resources/features/charges-delta-consumer-delete-flows.feature
@@ -37,7 +37,7 @@ Feature: Process Charges Delete Delta information with happy and error condition
 
     Examples:
       | response | deltaMessage                       | companyNumber | chargeId                    | responseCode | targetTopic                                  |
-      | 400      | charges-delete-delta-source-1.json | 0             | NLVXY861zxOTr3NExemI3q4Nq4Y | 400          | charges-delta-charges-delta-consumer-invalid |
+      | 400      | charges-delete-delta-source-1.json | 12345678      | NLVXY861zxOTr3NExemI3q4Nq4Y | 400          | charges-delta-charges-delta-consumer-invalid |
 
   Scenario Outline: Consume a valid delete message, Charges Data API delete endpoint returns 503
 
@@ -49,8 +49,8 @@ Feature: Process Charges Delete Delta information with happy and error condition
 
     Examples:
       | response | deltaMessage                       | companyNumber | chargeId                    | responseCode | targetTopic                                | retries |
-      | 503      | charges-delete-delta-source-1.json | 0             | NLVXY861zxOTr3NExemI3q4Nq4Y | 503          | charges-delta-charges-delta-consumer-error | 4       |
-      | 404      | charges-delete-delta-source-1.json | 0             | NLVXY861zxOTr3NExemI3q4Nq4Y | 404          | charges-delta-charges-delta-consumer-error | 4       |
+      | 503      | charges-delete-delta-source-1.json | 12345678      | NLVXY861zxOTr3NExemI3q4Nq4Y | 503          | charges-delta-charges-delta-consumer-error | 4       |
+      | 404      | charges-delete-delta-source-1.json | 12345678      | NLVXY861zxOTr3NExemI3q4Nq4Y | 404          | charges-delta-charges-delta-consumer-error | 4       |
 
   Scenario Outline: Consume a valid delete message, but fails while processing before calling Charges Data API delete endpoint
 
@@ -62,7 +62,7 @@ Feature: Process Charges Delete Delta information with happy and error condition
 
     Examples:
       | response | deltaMessage                       | companyNumber | chargeId                    | responseCode | targetTopic                                | retries |  |
-      | 500      | charges-delete-delta-source-1.json | 0             | NLVXY861zxOTr3NExemI3q4Nq4Y | 500          | charges-delta-charges-delta-consumer-error | 4       |  |
+      | 500      | charges-delete-delta-source-1.json | 12345678      | NLVXY861zxOTr3NExemI3q4Nq4Y | 500          | charges-delta-charges-delta-consumer-error | 4       |  |
 
   Scenario Outline: Consume a Charges Delete message null/empty charge id,
   process it and move to invalid message topic charges data api never called
@@ -75,5 +75,5 @@ Feature: Process Charges Delete Delta information with happy and error condition
 
     Examples:
       | response | targetTopic                                  | deltaMessage                                     | companyNumber | chargeId                    |
-      | 200      | charges-delta-charges-delta-consumer-invalid | charges-delete-delta-source-null_charge-id.json  | 0             | NLVXY861zxOTr3NExemI3q4Nq4Y |
-      | 200      | charges-delta-charges-delta-consumer-invalid | charges-delete-delta-source-empty_charge-id.json | 0             | NLVXY861zxOTr3NExemI3q4Nq4Y |
+      | 200      | charges-delta-charges-delta-consumer-invalid | charges-delete-delta-source-null_charge-id.json  | 12345678      | NLVXY861zxOTr3NExemI3q4Nq4Y |
+      | 200      | charges-delta-charges-delta-consumer-invalid | charges-delete-delta-source-empty_charge-id.json | 12345678      | NLVXY861zxOTr3NExemI3q4Nq4Y |

--- a/src/itest/resources/payloads/input/charges-delete-delta-source-1.json
+++ b/src/itest/resources/payloads/input/charges-delete-delta-source-1.json
@@ -1,5 +1,6 @@
 {
   "charges_id": "3000606655",
   "action": "DELETE",
-  "delta_at": "20230724093435661593"
+  "delta_at": "20230724093435661593",
+  "company_number" : "12345678"
 }

--- a/src/main/java/uk/gov/companieshouse/charges/delta/processor/ChargesDeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/charges/delta/processor/ChargesDeltaProcessor.java
@@ -87,6 +87,7 @@ public class ChargesDeltaProcessor {
     public void processDelete(Message<ChsDelta> chsDelta) {
         final ChargesDeleteDelta chargesDeleteDelta =
                 mapToChargesDelta(chsDelta.getPayload(), ChargesDeleteDelta.class);
+        String deltaAt = chargesDeleteDelta.getDeltaAt();
         DataMapHolder.get().mortgageId(chargesDeleteDelta.getChargesId());
 
         Optional<String> chargeIdOptional = Optional.ofNullable(chargesDeleteDelta.getChargesId())
@@ -96,7 +97,7 @@ public class ChargesDeltaProcessor {
         final String chargeId = encoderUtil.encodeWithSha1(chargeIdOptional.orElseThrow(
                 () -> new NonRetryableErrorException("Charge Id is empty!")));
 
-        final ApiResponse<Void> apiResponse = deleteCharge(chargeId);
+        final ApiResponse<Void> apiResponse = deleteCharge(chargeId, deltaAt);
 
         handleDeleteResponse(HttpStatus.valueOf(apiResponse.getStatusCode()));
     }
@@ -157,8 +158,8 @@ public class ChargesDeltaProcessor {
     /**
      * Invoke Charges Data API to update charges database.
      */
-    private ApiResponse<Void> deleteCharge(String chargeId) {
-        return apiClientService.deleteCharge("0", chargeId);
+    private ApiResponse<Void> deleteCharge(String chargeId, String deltaAt) {
+        return apiClientService.deleteCharge("0", chargeId, deltaAt);
     }
 
     private void handleDeleteResponse(final HttpStatus httpStatus) {

--- a/src/main/java/uk/gov/companieshouse/charges/delta/processor/ChargesDeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/charges/delta/processor/ChargesDeltaProcessor.java
@@ -88,6 +88,7 @@ public class ChargesDeltaProcessor {
         final ChargesDeleteDelta chargesDeleteDelta =
                 mapToChargesDelta(chsDelta.getPayload(), ChargesDeleteDelta.class);
         String deltaAt = chargesDeleteDelta.getDeltaAt();
+        String companyNumber = chargesDeleteDelta.getCompanyNumber();
         DataMapHolder.get().mortgageId(chargesDeleteDelta.getChargesId());
 
         Optional<String> chargeIdOptional = Optional.ofNullable(chargesDeleteDelta.getChargesId())
@@ -97,7 +98,7 @@ public class ChargesDeltaProcessor {
         final String chargeId = encoderUtil.encodeWithSha1(chargeIdOptional.orElseThrow(
                 () -> new NonRetryableErrorException("Charge Id is empty!")));
 
-        final ApiResponse<Void> apiResponse = deleteCharge(chargeId, deltaAt);
+        final ApiResponse<Void> apiResponse = deleteCharge(companyNumber, chargeId, deltaAt);
 
         handleDeleteResponse(HttpStatus.valueOf(apiResponse.getStatusCode()));
     }
@@ -158,8 +159,8 @@ public class ChargesDeltaProcessor {
     /**
      * Invoke Charges Data API to update charges database.
      */
-    private ApiResponse<Void> deleteCharge(String chargeId, String deltaAt) {
-        return apiClientService.deleteCharge("0", chargeId, deltaAt);
+    private ApiResponse<Void> deleteCharge(String companyNumber, String chargeId, String deltaAt) {
+        return apiClientService.deleteCharge(companyNumber, chargeId, deltaAt);
     }
 
     private void handleDeleteResponse(final HttpStatus httpStatus) {

--- a/src/main/java/uk/gov/companieshouse/charges/delta/processor/ChargesDeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/charges/delta/processor/ChargesDeltaProcessor.java
@@ -75,8 +75,9 @@ public class ChargesDeltaProcessor {
         InternalChargeApi internalChargeApi = transformer.transform(charge, chsDelta.getHeaders());
 
         removeBrokenFilingLinks(internalChargeApi, charge.getCompanyNumber());
+        String chargeId = encoderUtil.encodeWithSha1(rawChargeId);
 
-        ApiResponse<Void> apiResponse = updateChargesData(rawChargeId, charge, internalChargeApi);
+        ApiResponse<Void> apiResponse = apiClientService.putCharge(charge.getCompanyNumber(), chargeId, internalChargeApi);;
 
         handleResponse(HttpStatus.valueOf(apiResponse.getStatusCode()));
     }
@@ -89,7 +90,7 @@ public class ChargesDeltaProcessor {
                 mapToChargesDelta(chsDelta.getPayload(), ChargesDeleteDelta.class);
         String deltaAt = chargesDeleteDelta.getDeltaAt();
         String companyNumber = chargesDeleteDelta.getCompanyNumber();
-        DataMapHolder.get().mortgageId(chargesDeleteDelta.getChargesId());
+        DataMapHolder.get().mortgageId(chargesDeleteDelta.getChargesId()).companyNumber(companyNumber);
 
         Optional<String> chargeIdOptional = Optional.ofNullable(chargesDeleteDelta.getChargesId())
                 .filter(Predicate.not(String::isEmpty));
@@ -98,7 +99,7 @@ public class ChargesDeltaProcessor {
         final String chargeId = encoderUtil.encodeWithSha1(chargeIdOptional.orElseThrow(
                 () -> new NonRetryableErrorException("Charge Id is empty!")));
 
-        final ApiResponse<Void> apiResponse = deleteCharge(companyNumber, chargeId, deltaAt);
+        final ApiResponse<Void> apiResponse = apiClientService.deleteCharge(companyNumber, chargeId, deltaAt);
 
         handleDeleteResponse(HttpStatus.valueOf(apiResponse.getStatusCode()));
     }
@@ -125,17 +126,6 @@ public class ChargesDeltaProcessor {
         }
     }
 
-    /**
-     * Invoke Charges Data API to update charges database.
-     */
-    private ApiResponse<Void> updateChargesData(String rawChargeId, Charge charge, InternalChargeApi internalChargeApi) {
-
-        //pass in the chargeId and encode it with base64 after doing a SHA1 hash
-        final String chargeId = encoderUtil.encodeWithSha1(rawChargeId);
-
-        return apiClientService.putCharge(charge.getCompanyNumber(), chargeId, internalChargeApi);
-    }
-
     private void handleResponse(final HttpStatus httpStatus)
             throws NonRetryableErrorException, RetryableErrorException {
         DataMapHolder.get().status(httpStatus.toString());
@@ -154,13 +144,6 @@ public class ChargesDeltaProcessor {
             LOGGER.info(message, DataMapHolder.getLogMap());
             throw new RetryableErrorException(message);
         }
-    }
-
-    /**
-     * Invoke Charges Data API to update charges database.
-     */
-    private ApiResponse<Void> deleteCharge(String companyNumber, String chargeId, String deltaAt) {
-        return apiClientService.deleteCharge(companyNumber, chargeId, deltaAt);
     }
 
     private void handleDeleteResponse(final HttpStatus httpStatus) {

--- a/src/main/java/uk/gov/companieshouse/charges/delta/service/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/charges/delta/service/ApiClientService.java
@@ -12,20 +12,16 @@ import uk.gov.companieshouse.api.model.ApiResponse;
 public interface ApiClientService {
 
     String PUT_CHARGE_URI = "/company/%s/charge/%s/internal";
-    String DELETE_CHARGE_URI = "/company/%s/charges/%s";
+    String DELETE_CHARGE_URI = "/company/%s/charge/%s/internal";
 
     /**
      * Submit charge.
      */
     ApiResponse<Void> putCharge(
-            final String companyNumber,
-            final String chargeId,
-            final InternalChargeApi internalChargeApi);
+            final String companyNumber, final String chargeId, final InternalChargeApi internalChargeApi);
 
     /**
      * Delete charge.
      */
-    ApiResponse<Void> deleteCharge(
-            final String companyNumber,
-            final String chargeId);
+    ApiResponse<Void> deleteCharge(final String companyNumber, final String chargeId, final String deltaAt);
 }

--- a/src/main/java/uk/gov/companieshouse/charges/delta/service/ApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/charges/delta/service/ApiClientServiceImpl.java
@@ -65,7 +65,7 @@ public class ApiClientServiceImpl implements ApiClientService {
     }
 
     @Override
-    public ApiResponse<Void> deleteCharge(String companyNumber, String chargeId) {
+    public ApiResponse<Void> deleteCharge(String companyNumber, String chargeId, String deltaAt) {
         final String formattedUri = String.format(DELETE_CHARGE_URI, companyNumber, chargeId);
         DataMapHolder.get().uri(formattedUri);
 
@@ -74,7 +74,7 @@ public class ApiClientServiceImpl implements ApiClientService {
 
         PrivateChargesDelete executor = internalApiClient
                 .privateDeltaChargeResourceHandler()
-                .deleteCharge(formattedUri);
+                .deleteCharge(formattedUri, deltaAt);
 
         return execute(executor);
     }

--- a/src/test/java/uk/gov/companieshouse/charges/delta/processor/ChargesDeltaProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/charges/delta/processor/ChargesDeltaProcessorTest.java
@@ -35,7 +35,7 @@ import uk.gov.companieshouse.delta.ChsDelta;
 
 @ExtendWith(MockitoExtension.class)
 class ChargesDeltaProcessorTest {
-    private static final String COMPANY_NUMBER = "0";
+    private static final String COMPANY_NUMBER = "12345678";
     private static final String CHARGE_ID = "yt6cQ-A2DqNpqwAMDWxKX12Axv4";
     private static final String DELTA_AT = "20230724093435661593";
 

--- a/src/test/java/uk/gov/companieshouse/charges/delta/processor/ChargesDeltaProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/charges/delta/processor/ChargesDeltaProcessorTest.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -30,11 +32,12 @@ import uk.gov.companieshouse.charges.delta.service.ApiClientService;
 import uk.gov.companieshouse.charges.delta.transformer.ChargesApiTransformer;
 import uk.gov.companieshouse.charges.delta.util.TestSupport;
 import uk.gov.companieshouse.delta.ChsDelta;
-import java.io.IOException;
-import java.util.stream.Stream;
 
 @ExtendWith(MockitoExtension.class)
 class ChargesDeltaProcessorTest {
+    private static final String COMPANY_NUMBER = "0";
+    private static final String CHARGE_ID = "yt6cQ-A2DqNpqwAMDWxKX12Axv4";
+    private static final String DELTA_AT = "20230724093435661593";
 
     private ChargesDeltaProcessor deltaProcessor;
 
@@ -118,12 +121,10 @@ class ChargesDeltaProcessorTest {
         Message<ChsDelta> mockChsChargesDeleteDeltaMessage = testSupport.createChsDeltaMessage(
                 "charges-delete-delta-source-1.json", true);
         final ApiResponse<Void> response = new ApiResponse<>(HttpStatus.OK.value(), null, null);
-        doReturn(response).when(apiClientService).deleteCharge("0",
-                "yt6cQ-A2DqNpqwAMDWxKX12Axv4");
-
+        doReturn(response).when(apiClientService).deleteCharge(COMPANY_NUMBER, CHARGE_ID, DELTA_AT);
         deltaProcessor.processDelete(mockChsChargesDeleteDeltaMessage);
 
-        verify(apiClientService).deleteCharge("0","yt6cQ-A2DqNpqwAMDWxKX12Axv4");
+        verify(apiClientService).deleteCharge(COMPANY_NUMBER, CHARGE_ID, DELTA_AT);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK.value());
     }
 
@@ -140,11 +141,10 @@ class ChargesDeltaProcessorTest {
         Message<ChsDelta> mockChsChargesDeleteDeltaMessage = testSupport.createChsDeltaMessage(
                 "charges-delete-delta-source-1.json", true);
         final ApiResponse<Void> response = new ApiResponse<>(HttpStatus.INTERNAL_SERVER_ERROR.value(), null, null);
-        doReturn(response).when(apiClientService).deleteCharge("0",
-                "yt6cQ-A2DqNpqwAMDWxKX12Axv4");
+        doReturn(response).when(apiClientService).deleteCharge(COMPANY_NUMBER, CHARGE_ID, DELTA_AT);
 
         assertThrows(RetryableErrorException.class, () -> deltaProcessor.processDelete(mockChsChargesDeleteDeltaMessage));
-        verify(apiClientService).deleteCharge("0","yt6cQ-A2DqNpqwAMDWxKX12Axv4");
+        verify(apiClientService).deleteCharge(COMPANY_NUMBER, CHARGE_ID, DELTA_AT);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
     }
 
@@ -154,11 +154,10 @@ class ChargesDeltaProcessorTest {
         Message<ChsDelta> mockChsChargesDeleteDeltaMessage = testSupport.createChsDeltaMessage(
                 "charges-delete-delta-source-1.json", true);
         final ApiResponse<Void> response = new ApiResponse<>(HttpStatus.NOT_FOUND.value(), null, null);
-        doReturn(response).when(apiClientService).deleteCharge("0",
-                "yt6cQ-A2DqNpqwAMDWxKX12Axv4");
+        doReturn(response).when(apiClientService).deleteCharge(COMPANY_NUMBER, CHARGE_ID, DELTA_AT);
 
         assertThrows(RetryableErrorException.class, () -> deltaProcessor.processDelete(mockChsChargesDeleteDeltaMessage));
-        verify(apiClientService).deleteCharge("0","yt6cQ-A2DqNpqwAMDWxKX12Axv4");
+        verify(apiClientService).deleteCharge(COMPANY_NUMBER, CHARGE_ID, DELTA_AT);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
     }
 
@@ -181,12 +180,10 @@ class ChargesDeltaProcessorTest {
         Message<ChsDelta> mockChsChargesDeleteDeltaMessage = testSupport.createChsDeltaMessage(
                 "charges-delete-delta-source-1.json", true);
         final ApiResponse<Void> response = new ApiResponse<>(httpStatus.value(), null, null);
-        doReturn(response).when(apiClientService).deleteCharge("0",
-                "yt6cQ-A2DqNpqwAMDWxKX12Axv4");
+        doReturn(response).when(apiClientService).deleteCharge(COMPANY_NUMBER, CHARGE_ID, DELTA_AT);
 
         assertThrows(exception, () -> deltaProcessor.processDelete(mockChsChargesDeleteDeltaMessage));
-        verify(apiClientService).deleteCharge("0",
-                "yt6cQ-A2DqNpqwAMDWxKX12Axv4");
+        verify(apiClientService).deleteCharge(COMPANY_NUMBER, CHARGE_ID, DELTA_AT);
         assertThat(response.getStatusCode()).isEqualTo(httpStatus.value());
     }
 
@@ -207,8 +204,7 @@ class ChargesDeltaProcessorTest {
         assertThrows( NonRetryableErrorException.class,
                 () -> deltaProcessor.processDelete(mockChsChargesDeleteDeltaMessage));
 
-        verify(apiClientService, times(0)).deleteCharge("0",
-                "yt6cQ-A2DqNpqwAMDWxKX12Axv4");
+        verify(apiClientService, times(0)).deleteCharge(COMPANY_NUMBER, CHARGE_ID, DELTA_AT);
     }
 
     private static Stream<Arguments> jsonPutFileSourceNames() {
@@ -228,8 +224,8 @@ class ChargesDeltaProcessorTest {
         assertThrows( NonRetryableErrorException.class,
                 () -> deltaProcessor.processDelta(mockChsChargesDeltaMessage));
 
-        verify(apiClientService, times(0)).putCharge("NI622400",
-                "yt6cQ-A2DqNpqwAMDWxKX12Axv4", testSupport.mockInternalChargeApi());
+        verify(apiClientService, times(0)).putCharge(COMPANY_NUMBER, CHARGE_ID,
+                testSupport.mockInternalChargeApi());
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/charges/delta/service/ApiClientServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/charges/delta/service/ApiClientServiceImplTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,7 +19,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -33,8 +34,6 @@ import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.http.HttpClient;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.charges.delta.exception.RetryableErrorException;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
 
 @TestPropertySource(
         properties = {
@@ -44,6 +43,9 @@ import java.util.stream.Stream;
 )
 @ExtendWith(MockitoExtension.class)
 class ApiClientServiceImplTest {
+    private static final String COMPANY_NUMBER = "12345678";
+    private static final String CHARGE_ID = "ABC134DEF5678";
+    private static final String DELTA_AT = "20140925171003950844";
 
     @Value("${api.charges-data-api-key}")
     private String apiKey;
@@ -144,18 +146,16 @@ class ApiClientServiceImplTest {
         when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
         when(internalApiClient.getHttpClient()).thenReturn(httpClient);
         when(internalApiClient.privateDeltaChargeResourceHandler()).thenReturn(privateDeltaResourceHandler);
-        when(privateDeltaResourceHandler.deleteCharge(Mockito.anyString())).thenReturn(privateChargesDelete);
+        when(privateDeltaResourceHandler.deleteCharge(anyString(), anyString())).thenReturn(privateChargesDelete);
         when(privateChargesDelete.execute()).thenReturn(response);
 
-        ApiResponse<?> apiResponse = apiClientService.deleteCharge(
-                "0111", "test");
+        ApiResponse<?> apiResponse = apiClientService.deleteCharge(COMPANY_NUMBER, CHARGE_ID, DELTA_AT);
 
         Assertions.assertThat(apiResponse).isNotNull();
 
         verify(internalApiClient, times(1)).getHttpClient();
         verify(internalApiClient, times(1)).privateDeltaChargeResourceHandler();
-        verify(privateDeltaResourceHandler, times(1))
-                .deleteCharge(Mockito.anyString());
+        verify(privateDeltaResourceHandler, times(1)).deleteCharge(anyString(), anyString());
         verify(privateChargesDelete, times(1))
                 .execute();
 
@@ -169,19 +169,18 @@ class ApiClientServiceImplTest {
         when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
         when(internalApiClient.getHttpClient()).thenReturn(httpClient);
         when(internalApiClient.privateDeltaChargeResourceHandler()).thenReturn(privateDeltaResourceHandler);
-        when(privateDeltaResourceHandler.deleteCharge(Mockito.anyString())).thenReturn(privateChargesDelete);
+        when(privateDeltaResourceHandler.deleteCharge(anyString(), anyString())).thenReturn(privateChargesDelete);
         when(privateChargesDelete.execute()).thenReturn(new ApiResponse<>(statusCode, null));
 
-        ApiResponse<?> apiResponse = assertDoesNotThrow(() -> apiClientService.deleteCharge(
-                "0", "test"));
+        ApiResponse<?> apiResponse = assertDoesNotThrow(() ->
+                apiClientService.deleteCharge(COMPANY_NUMBER, CHARGE_ID, DELTA_AT));
 
         Assertions.assertThat(apiResponse).isNotNull();
         Assertions.assertThat(apiResponse.getStatusCode()).isEqualTo(statusCode);
 
         verify(internalApiClient, times(1)).getHttpClient();
         verify(internalApiClient, times(1)).privateDeltaChargeResourceHandler();
-        verify(privateDeltaResourceHandler, times(1))
-                .deleteCharge(Mockito.anyString());
+        verify(privateDeltaResourceHandler, times(1)).deleteCharge(anyString(), anyString());
         verify(privateChargesDelete, times(1))
                 .execute();
 
@@ -194,16 +193,15 @@ class ApiClientServiceImplTest {
         when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
         when(internalApiClient.getHttpClient()).thenReturn(httpClient);
         when(internalApiClient.privateDeltaChargeResourceHandler()).thenReturn(privateDeltaResourceHandler);
-        when(privateDeltaResourceHandler.deleteCharge(Mockito.anyString())).thenReturn(privateChargesDelete);
+        when(privateDeltaResourceHandler.deleteCharge(anyString(), anyString())).thenReturn(privateChargesDelete);
         when(privateChargesDelete.execute()).thenThrow(URIValidationException.class);
 
-        assertThrows(RetryableErrorException.class, () -> apiClientService.deleteCharge(
-                "0", "test"));
+        assertThrows(RetryableErrorException.class, () ->
+                apiClientService.deleteCharge(COMPANY_NUMBER, CHARGE_ID, DELTA_AT));
 
         verify(internalApiClient, times(1)).getHttpClient();
         verify(internalApiClient, times(1)).privateDeltaChargeResourceHandler();
-        verify(privateDeltaResourceHandler, times(1))
-                .deleteCharge(Mockito.anyString());
+        verify(privateDeltaResourceHandler, times(1)).deleteCharge(anyString(), anyString());
         verify(privateChargesDelete, times(1))
                 .execute();
 

--- a/src/test/resources/charges-delete-delta-source-1.json
+++ b/src/test/resources/charges-delete-delta-source-1.json
@@ -1,5 +1,6 @@
 {
   "charges_id": "3000606655",
   "action": "DELETE",
-  "delta_at": "20230724093435661593"
+  "delta_at": "20230724093435661593",
+  "company_number" : "12345678"
 }


### PR DESCRIPTION
* Extract delta_at from delta and pass in API call
* Change processor method to use company number located in delta instead
* Awaiting local testing when API changes are completed

Resolves [DSND-3116](https://companieshouse.atlassian.net/browse/DSND-3116)


[DSND-3116]: https://companieshouse.atlassian.net/browse/DSND-3116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ