### PR TITLE
Add CODEOWNERS file for Toro Loco Dev approvals

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# List of Toro Loco Devs for approvals
+* @companieshouse/toro-loco-devs


### PR DESCRIPTION
Adds a CODEOWNERS configuration so GitHub can require the Toro Loco team to review/approve changes by default.
Changes:

Introduce a root-level CODEOWNERS file.
Set @companieshouse/toro-loco-devs as the owner for all paths (*).